### PR TITLE
Feature-23

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -78,7 +78,7 @@ android {
             // Disable debugging for release versions so it can be uploaded to Google Play.
             //debuggable true
             ndk {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
         debug {


### PR DESCRIPTION
Control Hub OpenCV crashes if there is 64-bit abiFilter so I had to delete it.
